### PR TITLE
switch to Bluebird

### DIFF
--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -1,3 +1,4 @@
+var Promise = require('bluebird');
 var skeemas = require('skeemas');
 var EventEmitter = require('events').EventEmitter;
 

--- a/lib/jrpc-schema.js
+++ b/lib/jrpc-schema.js
@@ -1,3 +1,4 @@
+var Promise = require('bluebird');
 var uid = -1;
 var Schema = require('./Schema');
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "version-bump": "^0.1.0"
   },
   "dependencies": {
-    "skeemas": "^1.1.6"
+    "skeemas": "^1.1.6",
+    "bluebird":"latest"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
Uses the Bluebird library for Promises instead of the native NodeJS one.
To make it compatible with older versions as well.
